### PR TITLE
トップページをランディングページとして刷新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a Next.js 14 App Router frontend written in TypeScript. Main application code lives in `src/app`, with page routes in `page.tsx`, shared layouts in `layout.tsx`, and server route handlers in `src/app/api/**/route.ts`. Reusable UI components live in `src/app/component`, shared helpers in `src/libs`, global theme setup in `src/theme.ts`, and domain types in `src/types`. Static assets are stored in `public`. Use the `@/*` path alias for imports from `src`.
+
+## Build, Test, and Development Commands
+- `npm install` — install dependencies.
+- `npm run dev` — start the local dev server at `http://localhost:3000`.
+- `npm run lint` — run ESLint with the Next.js ruleset.
+- `npm run build` — create a production build and catch type or route issues.
+- `npm run start` — run the built app locally after `npm run build`.
+
+## Coding Style & Naming Conventions
+Prefer TypeScript for new code. Follow the existing style: 2-space indentation, semicolons, and concise React function components. Use `PascalCase` for component files such as `GameDetail.tsx`, `camelCase` for helpers, and keep Next.js route filenames framework-standard (`page.tsx`, `layout.tsx`, `route.ts`). Keep types in `src/types` and name them clearly, for example `PlayerStats.ts`. Lint with `next/core-web-vitals`; there is no Prettier config in this repo, so match the surrounding file style when editing.
+
+## Testing Guidelines
+There is currently no dedicated test runner configured in `package.json`. For every change, at minimum run `npm run lint`, and run `npm run build` for changes that affect routing, API handlers, authentication, or production rendering. If you add tests later, keep them close to the feature or under a dedicated `tests` directory and name them after the unit under test.
+
+## Commit & Pull Request Guidelines
+Recent history favors short, descriptive commit messages, often in Japanese, for example `選手の詳細ページ作成` or `不要なコンポーネント削除`. Keep commits focused on one concern. Pull requests should include a clear summary, impacted routes or components, related issue links, and screenshots or short recordings for UI changes. Note any required environment variables or backend API changes.
+
+## Security & Configuration Tips
+Do not commit secrets. This app depends on environment variables including `API_ENDPOINT`, `AUTH0_ISSUER_BASE_URL`, `AUTH0_M2M_CLIENT_ID`, `AUTH0_M2M_CLIENT_SECRET`, and `BLOB_READ_WRITE_TOKEN`. Many `src/app/api` handlers proxy requests to the backend, so verify auth and request payload changes carefully.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
   images: {
     remotePatterns: [
       {

--- a/src/app/component/TopPage.tsx
+++ b/src/app/component/TopPage.tsx
@@ -1,78 +1,289 @@
-import { AppBar, Box, Button, Container, Link as MuiLink, Toolbar, Typography } from "@mui/material";
+import ArrowForwardRoundedIcon from "@mui/icons-material/ArrowForwardRounded";
+import EmojiEventsRoundedIcon from "@mui/icons-material/EmojiEventsRounded";
+import Groups2RoundedIcon from "@mui/icons-material/Groups2Rounded";
+import InsightsRoundedIcon from "@mui/icons-material/InsightsRounded";
+import SportsSoccerRoundedIcon from "@mui/icons-material/SportsSoccerRounded";
+import TimelineRoundedIcon from "@mui/icons-material/TimelineRounded";
+import VerifiedRoundedIcon from "@mui/icons-material/VerifiedRounded";
+import {
+  AppBar,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Container,
+  Stack,
+  Toolbar,
+  Typography,
+} from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import Image from "next/image";
-import NextLink from 'next/link';
-import topPageImage from '../../../public/maemob-toppage.webp';
-// import topPageImage from '../../../public/maemob-toppage-2.png';
+import NextLink from "next/link";
+import topPageDetailImage from "../../../public/maemob-toppage-3.png";
+import topPageImage from "../../../public/maemob-toppage.webp";
+
+const valueProps = [
+  {
+    title: "大会運営をひとつに",
+    description: "大会作成、チーム登録、試合進行を1つの画面遷移で管理できます。",
+    icon: <EmojiEventsRoundedIcon color="primary" sx={{ fontSize: 32 }} />,
+  },
+  {
+    title: "試合結果をすばやく記録",
+    description: "得点、カード、MOM、PKストップまで現場でそのまま入力できます。",
+    icon: <SportsSoccerRoundedIcon color="primary" sx={{ fontSize: 32 }} />,
+  },
+  {
+    title: "個人とチームの成績を可視化",
+    description: "得点・アシスト・失点率などをランキングで振り返れます。",
+    icon: <InsightsRoundedIcon color="primary" sx={{ fontSize: 32 }} />,
+  },
+];
+
+const steps = [
+  {
+    title: "ユーザー登録してログイン",
+    description: "Auth0認証ですぐに利用開始。チーム運営者ごとに安全に管理できます。",
+  },
+  {
+    title: "大会とチームを登録",
+    description: "大会を作成し、参加チームや所属選手の情報を整理します。",
+  },
+  {
+    title: "試合結果を入力して共有",
+    description: "試合ごとの記録がそのまま集計され、ランキングや戦績に反映されます。",
+  },
+];
+
+const featurePoints = [
+  {
+    title: "対戦結果の記録",
+    description: "スコア、コメント、試合詳細まで記録して大会の履歴を残せます。",
+    icon: <TimelineRoundedIcon color="primary" sx={{ fontSize: 28 }} />,
+  },
+  {
+    title: "チーム・選手情報の整理",
+    description: "チーム単位でも選手単位でも、見たい情報へすぐアクセスできます。",
+    icon: <Groups2RoundedIcon color="primary" sx={{ fontSize: 28 }} />,
+  },
+  {
+    title: "運営しやすい集計画面",
+    description: "ランキングや成績表示が揃っているので、運営の手間を減らせます。",
+    icon: <VerifiedRoundedIcon color="primary" sx={{ fontSize: 28 }} />,
+  },
+];
 
 export const TopPageComponent = () => {
   return (
-    <>
-      <Box sx={{ flexGrow: 1 }}>
-        <AppBar position="static">
-          <Toolbar>
-            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+    <Box sx={{ bgcolor: "#f7fafc", color: "#0f172a" }}>
+      <AppBar position="sticky" color="transparent" elevation={0} sx={{ backdropFilter: "blur(10px)", bgcolor: "rgba(247, 250, 252, 0.9)", borderBottom: "1px solid #e2e8f0" }}>
+        <Container maxWidth="lg">
+          <Toolbar disableGutters sx={{ minHeight: 72 }}>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontWeight: 700 }}>
               MaeMob
             </Typography>
-            <MuiLink
+            <Button
               component={NextLink}
-              underline="none"
-              color={'white'}
               href={`/api/auth/login?returnTo=/conventions`}
+              variant="contained"
+              endIcon={<ArrowForwardRoundedIcon />}
             >
-              <Button color="inherit">Login</Button>
-            </MuiLink>
+              ログインして始める
+            </Button>
           </Toolbar>
-        </AppBar>
-        <Grid2 container>
-          <Grid2 xs={12}>
-            <Box sx={{
-              width: '100%',
-              height: 'auto',
-              overflow: 'hidden'
-            }}>
-              <Image
-                src={topPageImage}
-                alt="MaeMobイメージ画像"
-                layout="responsive"
-              />
-            </Box>
-          </Grid2>
-          <>
-            <Grid2 xs={12} display='flex' justifyContent='center'>
-              <Typography component='h2' variant="h2">使い方</Typography>
+        </Container>
+      </AppBar>
+
+      <Box component="main">
+        <Box
+          sx={{
+            background: "linear-gradient(180deg, #f8fbff 0%, #eef6ff 48%, #f7fafc 100%)",
+            borderBottom: "1px solid #e2e8f0",
+          }}
+        >
+          <Container maxWidth="lg" sx={{ py: { xs: 8, md: 12 } }}>
+            <Grid2 container spacing={6} alignItems="center">
+              <Grid2 xs={12} md={6}>
+                <Stack spacing={3}>
+                  <Chip label="FC24の大会・試合管理をスムーズに" color="primary" sx={{ width: "fit-content", fontWeight: 600 }} />
+                  <Typography component="h1" variant="h2" sx={{ fontWeight: 800, lineHeight: 1.15 }}>
+                    サッカー大会の運営を、
+                    <Box component="span" sx={{ color: "primary.main", display: "block" }}>
+                      もっとシンプルに。
+                    </Box>
+                  </Typography>
+                  <Typography variant="h6" color="text.secondary" sx={{ lineHeight: 1.8 }}>
+                    MaeMobは、大会登録・試合結果入力・個人成績の集計までを一元化する運営向けアプリです。
+                    現場で記録しやすく、あとから見返しやすい体験に整えています。
+                  </Typography>
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                    <Button
+                      component={NextLink}
+                      href="/api/auth/login?returnTo=/conventions"
+                      size="large"
+                      variant="contained"
+                      endIcon={<ArrowForwardRoundedIcon />}
+                    >
+                      無料で始める
+                    </Button>
+                    <Button component={NextLink} href="#features" size="large" variant="outlined">
+                      機能を見る
+                    </Button>
+                  </Stack>
+                </Stack>
+              </Grid2>
+              <Grid2 xs={12} md={6}>
+                <Box
+                  sx={{
+                    overflow: "hidden",
+                    borderRadius: 6,
+                    border: "1px solid #dbeafe",
+                    boxShadow: "0 20px 60px rgba(15, 23, 42, 0.12)",
+                    bgcolor: "#ffffff",
+                  }}
+                >
+                  <Image src={topPageImage} alt="MaeMobのトップイメージ" priority style={{ width: "100%", height: "auto", display: "block" }} />
+                </Box>
+              </Grid2>
             </Grid2>
-          </>
-          <>
-            <Grid2 xs={0} md={3} display='flex' justifyContent='center'>
-            </Grid2>
-            <Grid2 xs={12} md={6} display='flex' justifyContent='left'>
-              <Typography component='h2' variant="h4">①ユーザー登録</Typography>
-            </Grid2>
-            <Grid2 xs={0} md={3} display='flex' justifyContent='center'>
-            </Grid2>
-          </>
-          <>
-            <Grid2 xs={0} md={3} display='flex' justifyContent='center'>
-            </Grid2>
-            <Grid2 xs={12} md={6} display='flex' justifyContent='left'>
-              <Typography component='h2' variant="h4">②大会を登録</Typography>
-            </Grid2>
-            <Grid2 xs={0} md={3} display='flex' justifyContent='center'>
-            </Grid2>
-          </>
-        </Grid2>
-        <Box height='150px'></Box>
-        <AppBar component="footer" position="static" sx={{ backgroundColor: '#000000' }}>
-          <Container maxWidth="md">
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="caption">
-                ©2024 engr-sng
-              </Typography>
-            </Box>
           </Container>
-        </AppBar>
+        </Box>
+
+        <Container maxWidth="lg" sx={{ py: { xs: 8, md: 10 } }}>
+          <Grid2 container spacing={3}>
+            {valueProps.map((item) => (
+              <Grid2 xs={12} md={4} key={item.title}>
+                <Card sx={{ height: "100%", borderRadius: 4, boxShadow: "none", border: "1px solid #e2e8f0" }}>
+                  <CardContent sx={{ p: 4 }}>
+                    <Stack spacing={2}>
+                      {item.icon}
+                      <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                        {item.title}
+                      </Typography>
+                      <Typography color="text.secondary" sx={{ lineHeight: 1.8 }}>
+                        {item.description}
+                      </Typography>
+                    </Stack>
+                  </CardContent>
+                </Card>
+              </Grid2>
+            ))}
+          </Grid2>
+        </Container>
+
+        <Box id="features" sx={{ bgcolor: "#ffffff", borderTop: "1px solid #e2e8f0", borderBottom: "1px solid #e2e8f0" }}>
+          <Container maxWidth="lg" sx={{ py: { xs: 8, md: 10 } }}>
+            <Grid2 container spacing={6} alignItems="center">
+              <Grid2 xs={12} md={5}>
+                <Stack spacing={2.5}>
+                  <Typography variant="overline" color="primary.main" sx={{ fontWeight: 700 }}>
+                    Features
+                  </Typography>
+                  <Typography component="h2" variant="h3" sx={{ fontWeight: 800 }}>
+                    日々の運営に必要な情報へ、
+                    迷わずたどり着けます。
+                  </Typography>
+                  <Typography color="text.secondary" sx={{ lineHeight: 1.9 }}>
+                    MaeMobは入力しやすさだけでなく、運営後の振り返りにも強い構成です。大会・チーム・選手の情報が整理され、必要なデータをすばやく確認できます。
+                  </Typography>
+                  <Stack spacing={2} sx={{ pt: 1 }}>
+                    {featurePoints.map((item) => (
+                      <Stack direction="row" spacing={2} alignItems="flex-start" key={item.title}>
+                        <Box sx={{ mt: 0.5 }}>{item.icon}</Box>
+                        <Box>
+                          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                            {item.title}
+                          </Typography>
+                          <Typography color="text.secondary" sx={{ lineHeight: 1.8 }}>
+                            {item.description}
+                          </Typography>
+                        </Box>
+                      </Stack>
+                    ))}
+                  </Stack>
+                </Stack>
+              </Grid2>
+              <Grid2 xs={12} md={7}>
+                <Box
+                  sx={{
+                    overflow: "hidden",
+                    borderRadius: 6,
+                    border: "1px solid #e2e8f0",
+                    boxShadow: "0 20px 60px rgba(15, 23, 42, 0.08)",
+                    bgcolor: "#ffffff",
+                  }}
+                >
+                  <Image src={topPageDetailImage} alt="MaeMobの画面イメージ" style={{ width: "100%", height: "auto", display: "block" }} />
+                </Box>
+              </Grid2>
+            </Grid2>
+          </Container>
+        </Box>
+
+        <Container maxWidth="lg" sx={{ py: { xs: 8, md: 10 } }}>
+          <Stack spacing={2} sx={{ mb: 4, textAlign: { xs: "left", md: "center" } }}>
+            <Typography variant="overline" color="primary.main" sx={{ fontWeight: 700 }}>
+              How It Works
+            </Typography>
+            <Typography component="h2" variant="h3" sx={{ fontWeight: 800 }}>
+              導入は3ステップです。
+            </Typography>
+          </Stack>
+          <Grid2 container spacing={3}>
+            {steps.map((step, index) => (
+              <Grid2 xs={12} md={4} key={step.title}>
+                <Card sx={{ height: "100%", borderRadius: 4, boxShadow: "none", border: "1px solid #e2e8f0", bgcolor: "#ffffff" }}>
+                  <CardContent sx={{ p: 4 }}>
+                    <Stack spacing={2}>
+                      <Typography color="primary.main" sx={{ fontWeight: 800 }}>
+                        STEP {index + 1}
+                      </Typography>
+                      <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                        {step.title}
+                      </Typography>
+                      <Typography color="text.secondary" sx={{ lineHeight: 1.8 }}>
+                        {step.description}
+                      </Typography>
+                    </Stack>
+                  </CardContent>
+                </Card>
+              </Grid2>
+            ))}
+          </Grid2>
+        </Container>
+
+        <Box sx={{ bgcolor: "#0f172a", color: "#ffffff" }}>
+          <Container maxWidth="md" sx={{ py: { xs: 8, md: 10 }, textAlign: "center" }}>
+            <Stack spacing={3} alignItems="center">
+              <Typography component="h2" variant="h3" sx={{ fontWeight: 800 }}>
+                大会運営を、記録から共有までスムーズに。
+              </Typography>
+              <Typography sx={{ color: "rgba(255, 255, 255, 0.76)", lineHeight: 1.9 }}>
+                まずはログインして大会を作成し、MaeMobの管理フローを体験してください。
+              </Typography>
+              <Button
+                component={NextLink}
+                href="/api/auth/login?returnTo=/conventions"
+                size="large"
+                variant="contained"
+                color="primary"
+                endIcon={<ArrowForwardRoundedIcon />}
+              >
+                ログインして大会管理を始める
+              </Button>
+            </Stack>
+          </Container>
+        </Box>
       </Box>
-    </>
-  )
+
+      <Box component="footer" sx={{ bgcolor: "#020617", color: "rgba(255, 255, 255, 0.72)", py: 3 }}>
+        <Container maxWidth="lg">
+          <Typography variant="body2" align="center">
+            ©2024 MaeMob
+          </Typography>
+        </Container>
+      </Box>
+    </Box>
+  );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { TopPageComponent } from "./component/TopPage";
+
+export const metadata: Metadata = {
+  title: "MaeMob | サッカー大会・試合管理アプリ",
+  description: "MaeMobは、大会登録・試合結果入力・個人成績の集計までを一元管理できるサッカー大会運営向けアプリです。",
+};
 
 const TopPage = () => {
   return (


### PR DESCRIPTION
## 概要
- トップページをランディングページ構成に刷新
- ホーム画面のメタデータを MaeMob 向けに更新
- リポジトリ向けの `AGENTS.md` を追加

## 変更内容
- ヒーロー、価値訴求、機能紹介、導入ステップ、CTA を追加
- `src/app/component/TopPage.tsx` を LP デザインへ差し替え
- `src/app/page.tsx` にタイトルと description を追加
- `AGENTS.md` にコントリビューターガイドを追加

## 変更ファイル
- `src/app/component/TopPage.tsx`
- `src/app/page.tsx`
- `AGENTS.md`

## 確認
- `npm run lint`
- `npm run build`

## 補足
- `next.config.mjs` の `experimental.serverActions` に Next.js 14 の不要設定警告あり
- `sharp` 未導入のため、本番 Image Optimization の推奨警告あり
- 今回の変更自体に起因する lint / build エラーはなし